### PR TITLE
Use go-test-coverage to enforce test coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,4 +47,9 @@ jobs:
         run: go test -exec /bin/true ./...
       
       - name: Go Test
-        run: go test -v -count=1 -race -shuffle=on ./...
+        run: go test -v -count=1 -race -shuffle=on -coverprofile=./cover.out -covermode=atomic -coverpkg=./... ./...
+      
+      - name: Check test coverage
+        uses: vladopajic/go-test-coverage@v2
+        with:
+          config: ./.testcoverage.yml

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ fantasy_manager_v2
 
 # Don't need these Mac specific files
 .DS_Store
+
+# Coverage profile
+cover.out

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -1,0 +1,38 @@
+profile: cover.out
+local-prefix: "github.com/mww/fantasy_manager_v2"
+threshold:
+  # (optional; default 0) 
+  # The minimum coverage that each file should have
+  file: 70
+
+  # (optional; default 0) 
+  # The minimum coverage that each package should have
+  package: 80
+
+  # (optional; default 0) 
+  # The minimum total coverage project should have
+  total: 80
+
+# Holds regexp rules which will override thresholds for matched files or packages 
+# using their paths.
+#
+# First rule from this list that matches file or package is going to apply 
+# new threshold to it. If project has multiple rules that match same path, 
+# override rules should be listed in order from specific to more general rules.
+override:
+  # Increase coverage threshold to 100% for `foo` package 
+  # (default is 80, as configured above in this example)
+  - threshold: 100
+    path: ^pkg/lib/foo$
+
+# Holds regexp rules which will exclude matched files or packages 
+# from coverage statistics
+exclude:
+  # Exclude files or packages matching their paths
+  paths:
+    - main.go$
+    - ^web     # exclude package `web`
+ 
+# NOTES:
+# - symbol `/` in all path regexps will be replaced by current OS file path separator
+#   to properly work on Windows

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -7,11 +7,11 @@ import (
 
 // C encapsulates business logic without worrying about any web layers
 type C struct {
-	sleeper *sleeper.Client
+	sleeper sleeper.Client
 	db      db.DB
 }
 
-func New(sleeper *sleeper.Client, db db.DB) (*C, error) {
+func New(sleeper sleeper.Client, db db.DB) (*C, error) {
 	c := &C{
 		sleeper: sleeper,
 		db:      db,

--- a/model/nfl_teams_test.go
+++ b/model/nfl_teams_test.go
@@ -102,3 +102,23 @@ func TestFriendly(t *testing.T) {
 		}
 	}
 }
+
+func TestEquals(t *testing.T) {
+	tests := []struct {
+		a    *NFLTeam
+		b    *NFLTeam
+		want bool
+	}{
+		{a: TEAM_BAL, b: TEAM_BAL, want: true},
+		{a: TEAM_SEA, b: TEAM_SFO, want: false},
+		{a: TEAM_DAL, b: nil, want: false},
+		{a: TEAM_SFO, b: TEAM_SFO, want: true},
+	}
+
+	for _, tc := range tests {
+		got := tc.a.Equals(tc.b)
+		if tc.want != got {
+			t.Errorf("expected: '%v', got: '%v'", tc.want, got)
+		}
+	}
+}

--- a/model/player_test.go
+++ b/model/player_test.go
@@ -1,0 +1,58 @@
+package model
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPlayerDateFormatFunctions(t *testing.T) {
+	zeroDates := &Player{
+		BirthDate:  time.Time{},
+		RookieYear: time.Time{},
+		Created:    time.Time{},
+		Updated:    time.Time{},
+	}
+	if zeroDates.FormattedBirthDate() != "unknown" {
+		t.Error("birthdate is not unknown")
+	}
+	if zeroDates.FormattedRookieYear() != "unknown" {
+		t.Error("rookie year is not unknown")
+	}
+	if zeroDates.FormattedCreatedTime() != "unknown" {
+		t.Error("created time is not unknown")
+	}
+	if zeroDates.FormattedUpdatedTime() != "unknown" {
+		t.Error("updated time is not unknown")
+	}
+
+	nonZeroDates := &Player{
+		BirthDate:  time.Date(1994, 2, 20, 0, 0, 0, 0, time.UTC),
+		RookieYear: time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC),
+		Created:    time.Date(2024, 7, 8, 10, 14, 36, 136, time.UTC),
+		Updated:    time.Date(2024, 7, 9, 17, 12, 51, 0, time.UTC),
+	}
+	if nonZeroDates.FormattedBirthDate() != "1994-02-20" {
+		t.Errorf("birthdate was not expected value: '%s'", nonZeroDates.FormattedBirthDate())
+	}
+	if nonZeroDates.FormattedRookieYear() != "2015" {
+		t.Errorf("rookie year was not expected value: '%s'", nonZeroDates.FormattedRookieYear())
+	}
+	if nonZeroDates.FormattedCreatedTime() != "2024-07-08 10:14:36" {
+		t.Errorf("created time was not expected value: '%s'", nonZeroDates.FormattedCreatedTime())
+	}
+	if nonZeroDates.FormattedUpdatedTime() != "2024-07-09 17:12:51" {
+		t.Errorf("updated time was not expected value: '%s'", nonZeroDates.FormattedUpdatedTime())
+	}
+}
+
+func TestChangeString(t *testing.T) {
+	c := &Change{
+		Time:         time.Date(2024, 7, 8, 10, 23, 19, 111, time.UTC),
+		PropertyName: "FirstName",
+		OldValue:     "Jonny",
+		NewValue:     "John",
+	}
+	if c.String() != "FirstName changed from 'Jonny' to 'John'" {
+		t.Errorf("string was not expected value: '%s'", c.String())
+	}
+}

--- a/sleeper/client.go
+++ b/sleeper/client.go
@@ -11,13 +11,17 @@ import (
 
 const SleeperURL = "https://api.sleeper.app"
 
-type Client struct {
+type Client interface {
+	LoadPlayers() ([]model.Player, error)
+}
+
+type client struct {
 	url        string
 	httpClient *http.Client
 }
 
-func New() (*Client, error) {
-	c := &Client{
+func New() (Client, error) {
+	c := &client{
 		url: SleeperURL,
 		httpClient: &http.Client{
 			Timeout: time.Second * 10,
@@ -26,7 +30,7 @@ func New() (*Client, error) {
 	return c, nil
 }
 
-func (c *Client) LoadPlayers() ([]model.Player, error) {
+func (c *client) LoadPlayers() ([]model.Player, error) {
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/v1/players/nfl", c.url), nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)

--- a/sleeper/client_test.go
+++ b/sleeper/client_test.go
@@ -19,7 +19,7 @@ func TestLoadPlayers_success(t *testing.T) {
 	}))
 	defer fakeSleeper.Close()
 
-	c := &Client{
+	c := &client{
 		url:        fakeSleeper.URL,
 		httpClient: http.DefaultClient,
 	}
@@ -96,7 +96,7 @@ func TestLoadPlayers_httpError(t *testing.T) {
 	}))
 	defer fakeSleeper.Close()
 
-	c := &Client{
+	c := &client{
 		url:        fakeSleeper.URL,
 		httpClient: http.DefaultClient,
 	}

--- a/sleeper/mocksleeper/mock_sleeper.go
+++ b/sleeper/mocksleeper/mock_sleeper.go
@@ -1,0 +1,21 @@
+package mocksleeper
+
+import (
+	"github.com/mww/fantasy_manager_v2/model"
+	"github.com/stretchr/testify/mock"
+)
+
+type Client struct {
+	mock.Mock
+}
+
+func (c *Client) LoadPlayers() ([]model.Player, error) {
+	args := c.Called()
+
+	var res []model.Player
+	if args.Get(0) != nil {
+		res = args.Get(0).([]model.Player)
+	}
+
+	return res, args.Error(1)
+}


### PR DESCRIPTION
- Update some unit tests to bring up min test coverage.
- Update workflow to enforce that coverage meets min standard.