### PR TITLE
Remove running go test in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,8 @@ ARG TARGETARCH
 WORKDIR /app/
 ADD . .
 RUN go mod download
-# For now ignore the tests in ./db because they use testcontainers and that
-# wasn't working with a simple `go test ./...`
-RUN CGO_ENABLED=0 go test ./controller/... ./model/... ./sleeper/... ./web/...
+# Skip running go test because most of the tests use testcontainers which
+# don't run in the docker build step.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o fantasy_manager_v2
 
 FROM --platform=${TARGETPLATFORM:-linux/amd64} scratch


### PR DESCRIPTION
The tests were failing because they couldn't start up testcontainers. For now just remove them.