### PR TITLE
Fix update player handler

### DIFF
--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS players (
     created           timestamp with time zone DEFAULT (now() at time zone 'utc'),
     updated           timestamp with time zone,
     fts_player        tsvector GENERATED ALWAYS AS (to_tsvector(
-        'english', name_first || ' ' || name_last || coalesce(nickname1, '')
+        'english', name_first || ' ' || name_last || ' ' || coalesce(nickname1, '')
     )) STORED
 );
 

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -100,7 +100,16 @@ func updatePlayerHandler(ctrl controller.C, render *render.Render) http.HandlerF
 			return
 		}
 
-		render.HTML(w, http.StatusOK, "player", p)
+		scores, err := ctrl.GetPlayerScores(r.Context(), playerID)
+		if err != nil {
+			log.Printf("error getting player scores: %v", err)
+		}
+
+		data := map[string]any{
+			"player": p,
+			"scores": scores,
+		}
+		render.HTML(w, http.StatusOK, "player", data)
 	}
 }
 


### PR DESCRIPTION
It hadn't been updated to work with the updated player template, so you always got an error after updating a nickname.

Also update fts_player column to have a space between last name and nickname. This makes searching a lot more useful. Need to run the following to update the DB:

ALTER TABLE players DROP COLUMN fts_player;
ALTER TABLE players ADD COLUMN fts_player tsvector GENERATED ALWAYS AS (to_tsvector('english', name_first || ' ' || name_last || ' ' || coalesce(nickname1, ''))) STORED;